### PR TITLE
chore: sync upstream

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.18', '1.21' ]
+
+    steps:
+      - name: install memcached
+        run: sudo apt-get install memcached
+      - uses: actions/checkout@v3
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Test
+        run: go test -v ./...

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,9 @@
+The following people & companies are the copyright holders of this
+package. Feel free to add to this list if you or your employer cares,
+otherwise it's implicit from the git log.
+
+Authors:
+
+- Brad Fitzpatrick
+- Google, Inc. (from Googlers contributing)
+- Anybody else in the git log.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ After this command *gomemcache* is ready to use. Its source will be in:
 
 ## Full docs, see:
 
-See https://godoc.org/github.com/bradfitz/gomemcache/memcache
+See https://pkg.go.dev/github.com/bradfitz/gomemcache/memcache
 
 Or run:
 

--- a/README.md
+++ b/README.md
@@ -7,25 +7,31 @@ This is a memcache client library for the Go programming language
 
 ### Using *go get*
 
-    $ go get github.com/bradfitz/gomemcache/memcache
+```shell
+$ go get github.com/bradfitz/gomemcache/memcache
+```
 
 After this command *gomemcache* is ready to use. Its source will be in:
 
-    $GOPATH/src/github.com/bradfitz/gomemcache/memcache
+```
+$GOPATH/src/github.com/bradfitz/gomemcache/memcache
+```
 
 ## Example
 
-    import (
-            "github.com/bradfitz/gomemcache/memcache"
-    )
+```go
+import (
+    "github.com/bradfitz/gomemcache/memcache"
+)
 
-    func main() {
-         mc := memcache.New("10.0.0.1:11211", "10.0.0.2:11211", "10.0.0.3:11212")
-         mc.Set(&memcache.Item{Key: "foo", Value: []byte("my value")})
+func main() {
+     mc := memcache.New("10.0.0.1:11211", "10.0.0.2:11211", "10.0.0.3:11212")
+     mc.Set(&memcache.Item{Key: "foo", Value: []byte("my value")})
 
-         it, err := mc.Get("foo")
-         ...
-    }
+     it, err := mc.Get("foo")
+     ...
+}
+```
 
 ## Full docs, see:
 
@@ -33,5 +39,7 @@ See https://pkg.go.dev/github.com/bradfitz/gomemcache/memcache
 
 Or run:
 
-    $ godoc github.com/bradfitz/gomemcache/memcache
+```shell
+$ godoc github.com/bradfitz/gomemcache/memcache
+```
 

--- a/README.md
+++ b/README.md
@@ -3,21 +3,15 @@
 This is a memcache client library for the Go programming language
 (http://golang.org/).
 
-## Installing
+## Example
 
-### Using *go get*
+Install with:
 
 ```shell
 $ go get github.com/bradfitz/gomemcache/memcache
 ```
 
-After this command *gomemcache* is ready to use. Its source will be in:
-
-```
-$GOPATH/src/github.com/bradfitz/gomemcache/memcache
-```
-
-## Example
+Then use it like:
 
 ```go
 import (

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/bradfitz/gomemcache
 
-go 1.12
+go 1.18

--- a/memcache/fakecerts_test.go
+++ b/memcache/fakecerts_test.go
@@ -1,0 +1,62 @@
+package memcache
+
+import "strings"
+
+// Copied from Go's net/http/internal/testcert package.
+
+// LocalhostCert is a PEM-encoded TLS cert with SAN IPs
+// "127.0.0.1" and "[::1]", expiring at Jan 29 16:00:00 2084 GMT.
+// generated from src/crypto/tls:
+// go run generate_cert.go  --rsa-bits 2048 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var LocalhostCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIDOTCCAiGgAwIBAgIQSRJrEpBGFc7tNb1fb5pKFzANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
+MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEA6Gba5tHV1dAKouAaXO3/ebDUU4rvwCUg/CNaJ2PT5xLD4N1Vcb8r
+bFSW2HXKq+MPfVdwIKR/1DczEoAGf/JWQTW7EgzlXrCd3rlajEX2D73faWJekD0U
+aUgz5vtrTXZ90BQL7WvRICd7FlEZ6FPOcPlumiyNmzUqtwGhO+9ad1W5BqJaRI6P
+YfouNkwR6Na4TzSj5BrqUfP0FwDizKSJ0XXmh8g8G9mtwxOSN3Ru1QFc61Xyeluk
+POGKBV/q6RBNklTNe0gI8usUMlYyoC7ytppNMW7X2vodAelSu25jgx2anj9fDVZu
+h7AXF5+4nJS4AAt0n1lNY7nGSsdZas8PbQIDAQABo4GIMIGFMA4GA1UdDwEB/wQE
+AwICpDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1Ud
+DgQWBBStsdjh3/JCXXYlQryOrL4Sh7BW5TAuBgNVHREEJzAlggtleGFtcGxlLmNv
+bYcEfwAAAYcQAAAAAAAAAAAAAAAAAAAAATANBgkqhkiG9w0BAQsFAAOCAQEAxWGI
+5NhpF3nwwy/4yB4i/CwwSpLrWUa70NyhvprUBC50PxiXav1TeDzwzLx/o5HyNwsv
+cxv3HdkLW59i/0SlJSrNnWdfZ19oTcS+6PtLoVyISgtyN6DpkKpdG1cOkW3Cy2P2
++tK/tKHRP1Y/Ra0RiDpOAmqn0gCOFGz8+lqDIor/T7MTpibL3IxqWfPrvfVRHL3B
+grw/ZQTTIVjjh4JBSW3WyWgNo/ikC1lrVxzl4iPUGptxT36Cr7Zk2Bsg0XqwbOvK
+5d+NTDREkSnUbie4GeutujmX3Dsx88UiV6UY/4lHJa6I5leHUNOHahRbpbWeOfs/
+WkBKOclmOV2xlTVuPw==
+-----END CERTIFICATE-----`)
+
+// LocalhostKey is the private key for LocalhostCert.
+var LocalhostKey = []byte(testingKey(`-----BEGIN RSA TESTING KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDoZtrm0dXV0Aqi
+4Bpc7f95sNRTiu/AJSD8I1onY9PnEsPg3VVxvytsVJbYdcqr4w99V3AgpH/UNzMS
+gAZ/8lZBNbsSDOVesJ3euVqMRfYPvd9pYl6QPRRpSDPm+2tNdn3QFAvta9EgJ3sW
+URnoU85w+W6aLI2bNSq3AaE771p3VbkGolpEjo9h+i42TBHo1rhPNKPkGupR8/QX
+AOLMpInRdeaHyDwb2a3DE5I3dG7VAVzrVfJ6W6Q84YoFX+rpEE2SVM17SAjy6xQy
+VjKgLvK2mk0xbtfa+h0B6VK7bmODHZqeP18NVm6HsBcXn7iclLgAC3SfWU1jucZK
+x1lqzw9tAgMBAAECggEABWzxS1Y2wckblnXY57Z+sl6YdmLV+gxj2r8Qib7g4ZIk
+lIlWR1OJNfw7kU4eryib4fc6nOh6O4AWZyYqAK6tqNQSS/eVG0LQTLTTEldHyVJL
+dvBe+MsUQOj4nTndZW+QvFzbcm2D8lY5n2nBSxU5ypVoKZ1EqQzytFcLZpTN7d89
+EPj0qDyrV4NZlWAwL1AygCwnlwhMQjXEalVF1ylXwU3QzyZ/6MgvF6d3SSUlh+sq
+XefuyigXw484cQQgbzopv6niMOmGP3of+yV4JQqUSb3IDmmT68XjGd2Dkxl4iPki
+6ZwXf3CCi+c+i/zVEcufgZ3SLf8D99kUGE7v7fZ6AQKBgQD1ZX3RAla9hIhxCf+O
+3D+I1j2LMrdjAh0ZKKqwMR4JnHX3mjQI6LwqIctPWTU8wYFECSh9klEclSdCa64s
+uI/GNpcqPXejd0cAAdqHEEeG5sHMDt0oFSurL4lyud0GtZvwlzLuwEweuDtvT9cJ
+Wfvl86uyO36IW8JdvUprYDctrQKBgQDycZ697qutBieZlGkHpnYWUAeImVA878sJ
+w44NuXHvMxBPz+lbJGAg8Cn8fcxNAPqHIraK+kx3po8cZGQywKHUWsxi23ozHoxo
++bGqeQb9U661TnfdDspIXia+xilZt3mm5BPzOUuRqlh4Y9SOBpSWRmEhyw76w4ZP
+OPxjWYAgwQKBgA/FehSYxeJgRjSdo+MWnK66tjHgDJE8bYpUZsP0JC4R9DL5oiaA
+brd2fI6Y+SbyeNBallObt8LSgzdtnEAbjIH8uDJqyOmknNePRvAvR6mP4xyuR+Bv
+m+Lgp0DMWTw5J9CKpydZDItc49T/mJ5tPhdFVd+am0NAQnmr1MCZ6nHxAoGABS3Y
+LkaC9FdFUUqSU8+Chkd/YbOkuyiENdkvl6t2e52jo5DVc1T7mLiIrRQi4SI8N9bN
+/3oJWCT+uaSLX2ouCtNFunblzWHBrhxnZzTeqVq4SLc8aESAnbslKL4i8/+vYZlN
+s8xtiNcSvL+lMsOBORSXzpj/4Ot8WwTkn1qyGgECgYBKNTypzAHeLE6yVadFp3nQ
+Ckq9yzvP/ib05rvgbvrne00YeOxqJ9gtTrzgh7koqJyX1L4NwdkEza4ilDWpucn0
+xiUZS4SoaJq6ZvcBYS62Yr1t8n09iG47YL8ibgtmH3L+svaotvpVxVK+d7BLevA/
+ZboOWVe3icTy64BT3OQhmg==
+-----END RSA TESTING KEY-----`))
+
+func testingKey(s string) string { return strings.ReplaceAll(s, "TESTING KEY", "PRIVATE KEY") }

--- a/memcache/fakeserver_test.go
+++ b/memcache/fakeserver_test.go
@@ -1,0 +1,269 @@
+package memcache
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type testServer struct {
+	mu      sync.Mutex
+	m       map[string]serverItem
+	nextCas uint64
+}
+
+type serverItem struct {
+	flags   uint32
+	data    []byte
+	exp     time.Time // or zero value for no expiry
+	casUniq uint64
+}
+
+func (s *testServer) Serve(l net.Listener) {
+	for {
+		c, err := l.Accept()
+		if err != nil {
+			return
+		}
+		tc := &testConn{s: s, c: c}
+		go tc.serve()
+	}
+}
+
+type testConn struct {
+	s  *testServer
+	c  net.Conn
+	br *bufio.Reader
+	bw *bufio.Writer
+}
+
+func (c *testConn) serve() {
+	defer c.c.Close()
+	c.br = bufio.NewReader(c.c)
+	c.bw = bufio.NewWriter(c.c)
+	for {
+		line, err := c.br.ReadSlice('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			return
+		}
+		if !c.handleRequestLine(string(line)) {
+			panic(fmt.Sprintf("unhandled request line in testServer: %q", line))
+		}
+	}
+}
+
+func (c *testConn) reply(msg string) bool {
+	fmt.Fprintf(c.bw, "%s\r\n", msg)
+	c.bw.Flush()
+	return true
+}
+
+var (
+	writeRx    = regexp.MustCompile(`^(set|add|replace|append|prepend|cas) (\S+) (\d+) (\d+) (\d+)( \S+)?( noreply)?\r\n`)
+	deleteRx   = regexp.MustCompile(`^delete (\S+)( noreply)?\r\n`)
+	incrDecrRx = regexp.MustCompile(`^(incr|decr) (\S+) (\d+)( noreply)?\r\n`)
+	touchRx    = regexp.MustCompile(`^touch (\S+) (\d+)( noreply)?\r\n`)
+)
+
+func (c *testConn) handleRequestLine(line string) bool {
+	c.s.mu.Lock()
+	defer c.s.mu.Unlock()
+
+	switch line {
+	case "quit\r\n":
+		return false
+	case "version\r\n":
+		return c.reply("VERSION go-client-unit-test")
+	case "flush_all\r\n":
+		c.s.m = make(map[string]serverItem)
+		return c.reply("OK")
+	}
+
+	if strings.HasPrefix(line, "gets ") {
+		keys := strings.Fields(strings.TrimPrefix(line, "gets "))
+		for _, key := range keys {
+			item, ok := c.s.m[key]
+			if !ok {
+				continue
+			}
+			if !item.exp.IsZero() && item.exp.Before(time.Now()) {
+				delete(c.s.m, key)
+				continue
+			}
+			fmt.Fprintf(c.bw, "VALUE %s %d %d %d\r\n", key, item.flags, len(item.data), item.casUniq)
+			c.bw.Write(item.data)
+			c.bw.Write(crlf)
+		}
+		return c.reply("END")
+	}
+
+	if m := deleteRx.FindStringSubmatch(line); m != nil {
+		key, noReply := m[1], strings.TrimSpace(m[2])
+		len0 := len(c.s.m)
+		delete(c.s.m, key)
+		len1 := len(c.s.m)
+		if noReply == "" {
+			if len0 == len1 {
+				return c.reply("NOT_FOUND")
+			}
+			return c.reply("DELETED")
+		}
+		return true
+	}
+
+	if m := touchRx.FindStringSubmatch(line); m != nil {
+		key, exptimeStr, noReply := m[1], m[2], strings.TrimSpace(m[3])
+		exptimeVal, _ := strconv.ParseInt(exptimeStr, 10, 64)
+
+		item, ok := c.s.m[key]
+		if ok {
+			item.exp = computeExpTime(exptimeVal)
+			c.s.m[key] = item
+		}
+		if noReply == "" {
+			if ok {
+				return c.reply("TOUCHED")
+			} else {
+				return c.reply("NOT_FOUND")
+			}
+		}
+		return true
+	}
+
+	if m := writeRx.FindStringSubmatch(line); m != nil {
+		verb, key, flagsStr, exptimeStr, lenStr, casUniq, noReply := m[1], m[2], m[3], m[4], m[5], m[6], strings.TrimSpace(m[7])
+		flags, _ := strconv.ParseUint(flagsStr, 10, 32)
+		exptimeVal, _ := strconv.ParseInt(exptimeStr, 10, 64)
+		itemLen, _ := strconv.ParseInt(lenStr, 10, 32)
+		//log.Printf("got %q flags=%q exp=%d %d len=%d cas=%q noreply=%q", verb, key, flags, exptimeVal, itemLen, casUniq, noReply)
+		_ = casUniq // TODO
+		if c.s.m == nil {
+			c.s.m = make(map[string]serverItem)
+		}
+		reply := func(msg string) bool {
+			if noReply != "noreply" {
+				c.reply(msg)
+			}
+			return true
+		}
+		body := make([]byte, itemLen+2)
+		if _, err := io.ReadFull(c.br, body); err != nil {
+			log.Printf("error reading %q body for key %q: %v", verb, key, err)
+			return false
+		}
+		if !bytes.HasSuffix(body, []byte("\r\n")) {
+			log.Printf("missing \\r\\n suffix for %q body for key %q", verb, key)
+			return false
+		}
+
+		was, ok := c.s.m[key]
+		if ok && (was.exp.After(time.Now()) || exptimeVal < 0) {
+			delete(c.s.m, key)
+			ok = false
+		}
+		c.s.nextCas++
+		newItem := serverItem{
+			flags:   uint32(flags),
+			data:    body[:itemLen],
+			casUniq: c.s.nextCas,
+			exp:     computeExpTime(exptimeVal),
+		}
+		switch verb {
+		case "set":
+			c.s.m[key] = newItem
+			return reply("STORED")
+		case "add":
+			if ok {
+				return reply("NOT_STORED")
+			}
+			c.s.m[key] = newItem
+			return reply("STORED")
+		case "replace":
+			if !ok {
+				return reply("NOT_STORED")
+			}
+			c.s.m[key] = newItem
+			return reply("STORED")
+		case "cas":
+			if !ok {
+				reply("NOT_FOUND")
+			}
+			return false
+		case "append":
+			if !ok {
+				return reply("NOT_STORED")
+			}
+			newItem.data = bytes.Join([][]byte{was.data, newItem.data}, nil)
+			c.s.m[key] = newItem
+			return reply("STORED")
+		case "prepend":
+			if !ok {
+				return reply("NOT_STORED")
+			}
+			newItem.data = bytes.Join([][]byte{newItem.data, was.data}, nil)
+			c.s.m[key] = newItem
+			return reply("STORED")
+		}
+	}
+
+	if m := incrDecrRx.FindStringSubmatch(line); m != nil {
+		verb, key, deltaStr, noReply := m[1], m[2], m[3], strings.TrimSpace(m[4])
+		delta, _ := strconv.ParseInt(deltaStr, 10, 64)
+		reply := func(msg string) bool {
+			if noReply != "noreply" {
+				c.reply(msg)
+			}
+			return true
+		}
+		item, ok := c.s.m[key]
+		if !ok {
+			return reply("NOT_FOUND")
+		}
+		oldVal, err := strconv.ParseInt(string(item.data), 10, 64)
+		if err != nil {
+			return reply("CLIENT_ERROR cannot increment or decrement non-numeric value")
+		}
+		var newVal int64
+		if verb == "decr" {
+			if delta < oldVal {
+				newVal = oldVal - delta
+			} else {
+				newVal = 0
+			}
+		} else {
+			newVal = oldVal + delta
+		}
+		item.data = []byte(strconv.FormatInt(newVal, 10))
+		c.s.m[key] = item
+		if noReply == "" {
+			fmt.Fprintf(c.bw, "%d\r\n", newVal)
+			c.bw.Flush()
+		}
+		return true
+	}
+
+	return false
+
+}
+
+func computeExpTime(n int64) time.Time {
+	if n == 0 {
+		return time.Time{}
+	}
+	if n <= 60*60*24*30 {
+		return time.Now().Add(time.Duration(n) * time.Second)
+	}
+	return time.Unix(n, 0)
+}

--- a/memcache/fakeserver_test.go
+++ b/memcache/fakeserver_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The gomemcache AUTHORS
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package memcache
 
 import (

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -255,11 +255,6 @@ func (cte *ConnectTimeoutError) Error() string {
 }
 
 func (c *Client) dial(addr net.Addr) (net.Conn, error) {
-	type connError struct {
-		cn  net.Conn
-		err error
-	}
-
 	nc, err := net.DialTimeout(addr.Network(), addr.String(), c.netTimeout())
 	if err == nil {
 		return nc, nil

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -561,6 +561,26 @@ func (c *Client) replace(rw *bufio.ReadWriter, item *Item) error {
 	return c.populateOne(rw, "replace", item)
 }
 
+// Append appends the given item to the existing item, if a value already
+// exists for its key. ErrNotStored is returned if that condition is not met.
+func (c *Client) Append(item *Item) error {
+	return c.onItem(item, (*Client).append)
+}
+
+func (c *Client) append(rw *bufio.ReadWriter, item *Item) error {
+	return c.populateOne(rw, "append", item)
+}
+
+// Prepend prepends the given item to the existing item, if a value already
+// exists for its key. ErrNotStored is returned if that condition is not met.
+func (c *Client) Prepend(item *Item) error {
+	return c.onItem(item, (*Client).prepend)
+}
+
+func (c *Client) prepend(rw *bufio.ReadWriter, item *Item) error {
+	return c.populateOne(rw, "prepend", item)
+}
+
 // CompareAndSwap writes the given item that was previously returned
 // by Get, if the value was neither modified or evicted between the
 // Get and the CompareAndSwap calls. The item's Key should not change

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -731,3 +731,24 @@ func (c *Client) incrDecr(verb, key string, delta uint64) (uint64, error) {
 	})
 	return val, err
 }
+
+// Close closes any open connections.
+//
+// It returns the first error encountered closing connections, but always
+// closes all connections.
+//
+// After Close, the Client may still be used.
+func (c *Client) Close() error {
+	c.lk.Lock()
+	defer c.lk.Unlock()
+	var ret error
+	for _, conns := range c.freeconn {
+		for _, c := range conns {
+			if err := c.nc.Close(); err != nil && ret == nil {
+				ret = err
+			}
+		}
+	}
+	c.freeconn = nil
+	return ret
+}

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2011 Google Inc.
+Copyright 2011 The gomemcache AUTHORS
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -130,20 +130,25 @@ var (
 // discoveryAddress should be in following form "ipv4-address:port"
 // Note: pollingDuration should be at least 1 second.
 func NewDiscoveryClient(discoveryAddress string, pollingDuration time.Duration) (*Client, error) {
-	return newDiscoveryClient(discoveryAddress, new(ServerList), pollingDuration)
-}
-
-func NewDynamicRendezvousClient(discoveryAddress string, pollingDuration time.Duration) (*Client, error) {
-	return newDiscoveryClient(discoveryAddress, NewRendezvousSelector(), pollingDuration)
-}
-
-// for the unit test
-func newDiscoveryClient(discoveryAddress string, selector ServerSelector, pollingDuration time.Duration) (*Client, error) {
 	// Validate pollingDuration
 	if pollingDuration.Seconds() < 1.0 {
 		return nil, ErrInvalidPollingDuration
 	}
 
+	return newDiscoveryClient(discoveryAddress, new(ServerList), pollingDuration)
+}
+
+func NewDynamicRendezvousClient(discoveryAddress string, pollingDuration time.Duration) (*Client, error) {
+	// Validate pollingDuration
+	if pollingDuration.Seconds() < 1.0 {
+		return nil, ErrInvalidPollingDuration
+	}
+
+	return newDiscoveryClient(discoveryAddress, NewRendezvousSelector(), pollingDuration)
+}
+
+// for the unit test
+func newDiscoveryClient(discoveryAddress string, selector ServerSelector, pollingDuration time.Duration) (*Client, error) {
 	// creates a new ServerList object which contains all the server eventually.
 	rand.Seed(time.Now().UnixNano())
 	mcCfgPollerHelper := New(discoveryAddress)

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -171,8 +171,11 @@ type Item struct {
 	// Zero means the Item has no expiration time.
 	Expiration int32
 
-	// Compare and swap ID.
-	casid uint64
+	// CasID is the compare and swap ID.
+	//
+	// It's populated by get requests and then the same value is
+	// required for a CompareAndSwap request to succeed.
+	CasID uint64
 }
 
 // conn is a connection to a server.
@@ -535,7 +538,7 @@ func parseGetResponse(r *bufio.Reader, cb func(*Item)) error {
 // It does not read the bytes of the item.
 func scanGetResponseLine(line []byte, it *Item) (size int, err error) {
 	pattern := "VALUE %s %d %d %d\r\n"
-	dest := []interface{}{&it.Key, &it.Flags, &size, &it.casid}
+	dest := []interface{}{&it.Key, &it.Flags, &size, &it.CasID}
 	if bytes.Count(line, space) == 3 {
 		pattern = "VALUE %s %d %d\r\n"
 		dest = dest[:3]
@@ -618,7 +621,7 @@ func (c *Client) populateOne(rw *bufio.ReadWriter, verb string, item *Item) erro
 	var err error
 	if verb == "cas" {
 		_, err = fmt.Fprintf(rw, "%s %s %d %d %d %d\r\n",
-			verb, item.Key, item.Flags, item.Expiration, len(item.Value), item.casid)
+			verb, item.Key, item.Flags, item.Expiration, len(item.Value), item.CasID)
 	} else {
 		_, err = fmt.Fprintf(rw, "%s %s %d %d %d\r\n",
 			verb, item.Key, item.Flags, item.Expiration, len(item.Value))

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -132,8 +132,12 @@ func NewFromSelector(ss ServerSelector) *Client {
 // Client is a memcache client.
 // It is safe for unlocked use by multiple concurrent goroutines.
 type Client struct {
-	// DialContext connects to the address on the named network
-	// using the provided context
+	// DialContext connects to the address on the named network using the
+	// provided context.
+	//
+	// To connect to servers using TLS (memcached running with "--enable-ssl"),
+	// use a DialContext func that uses tls.Dialer.DialContext. See this
+	// package's tests as an example.
 	DialContext func(ctx context.Context, network, address string) (net.Conn, error)
 
 	// Timeout specifies the socket read/write timeout.

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -65,7 +65,7 @@ var (
 
 const (
 	// DefaultTimeout is the default socket read/write timeout.
-	DefaultTimeout = 100 * time.Millisecond
+	DefaultTimeout = 500 * time.Millisecond
 
 	// DefaultMaxIdleConns is the default maximum number of idle connections
 	// kept for any single address.

--- a/memcache/memcache_discovery_test.go
+++ b/memcache/memcache_discovery_test.go
@@ -20,19 +20,17 @@ package memcache
 import (
 	"context"
 	"errors"
+	"net"
+	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
-
-	"net"
-	"os/exec"
-
 	"testing"
 	"time"
 )
 
 const (
-	testPollingTime          = 2 * time.Millisecond
+	testPollingTime          = 1 * time.Second
 	portLow                  = 49152
 	portHigh                 = 65535
 	memcachedCreationTimeout = 5 * time.Second

--- a/memcache/memcache_discovery_test.go
+++ b/memcache/memcache_discovery_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	testPollingTime          = 1 * time.Second
+	testPollingTime          = 2 * time.Millisecond
 	portLow                  = 49152
 	portHigh                 = 65535
 	memcachedCreationTimeout = 5 * time.Second

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2011 Google Inc.
+Copyright 2011 The gomemcache AUTHORS
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -141,6 +141,34 @@ func testWithClient(t *testing.T, c *Client) {
 		t.Fatalf("second add(foo) want ErrNotStored, got %v", err)
 	}
 
+	// Append
+	append := &Item{Key: "append", Value: []byte("appendval")}
+	if err := c.Append(append); err != ErrNotStored {
+		t.Fatalf("first append(append) want ErrNotStored, got %v", err)
+	}
+	c.Set(append)
+	err = c.Append(&Item{Key: "append", Value: []byte("1")})
+	checkErr(err, "second append(append): %v", err)
+	appended, err := c.Get("append")
+	checkErr(err, "third append(append): %v", err)
+	if string(appended.Value) != string(append.Value)+"1" {
+		t.Fatalf("Append: want=append1, got=%s", string(appended.Value))
+	}
+
+	// Prepend
+	prepend := &Item{Key: "prepend", Value: []byte("prependval")}
+	if err := c.Prepend(prepend); err != ErrNotStored {
+		t.Fatalf("first prepend(prepend) want ErrNotStored, got %v", err)
+	}
+	c.Set(prepend)
+	err = c.Prepend(&Item{Key: "prepend", Value: []byte("1")})
+	checkErr(err, "second prepend(prepend): %v", err)
+	prepended, err := c.Get("prepend")
+	checkErr(err, "third prepend(prepend): %v", err)
+	if string(prepended.Value) != "1"+string(prepend.Value) {
+		t.Fatalf("Prepend: want=1prepend, got=%s", string(prepended.Value))
+	}
+
 	// Replace
 	baz := &Item{Key: "baz", Value: []byte("bazvalue")}
 	if err := c.Replace(baz); err != ErrNotStored {

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -127,7 +127,7 @@ func testWithClient(t *testing.T, c *Client) {
 	if err != ErrMalformedKey {
 		t.Errorf("set(foo bar) should return ErrMalformedKey instead of %v", err)
 	}
-	malFormed = &Item{Key: "foo" + string(0x7f), Value: []byte("foobarval")}
+	malFormed = &Item{Key: "foo" + string(rune(0x7f)), Value: []byte("foobarval")}
 	err = c.Set(malFormed)
 	if err != ErrMalformedKey {
 		t.Errorf("set(foo<0x7f>) should return ErrMalformedKey instead of %v", err)

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -33,6 +33,7 @@ import (
 const localhostTCPAddr = "localhost:11211"
 
 func TestLocalhost(t *testing.T) {
+	t.Parallel()
 	c, err := net.Dial("tcp", localhostTCPAddr)
 	if err != nil {
 		t.Skipf("skipping test; no server running at %s", localhostTCPAddr)
@@ -45,6 +46,7 @@ func TestLocalhost(t *testing.T) {
 
 // Run the memcached binary as a child process and connect to its unix socket.
 func TestUnixSocket(t *testing.T) {
+	t.Parallel()
 	sock := fmt.Sprintf("/tmp/test-gomemcache-%d.sock", os.Getpid())
 	cmd := exec.Command("memcached", "-s", sock)
 	if err := cmd.Start(); err != nil {
@@ -66,6 +68,7 @@ func TestUnixSocket(t *testing.T) {
 }
 
 func TestFakeServer(t *testing.T) {
+	t.Parallel()
 	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)

--- a/memcache/selector.go
+++ b/memcache/selector.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2011 Google Inc.
+Copyright 2011 The gomemcache AUTHORS
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/memcache/selector_test.go
+++ b/memcache/selector_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Google Inc.
+Copyright 2014 The gomemcache AUTHORS
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Part of ADN-372

Pull in the latest changes from the upstream. This includes functionality to use TLS when connecting to memcache.