### PR TITLE
feat: add TLS support for discovery (ADN-372)

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -21,7 +21,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -136,7 +135,7 @@ func NewDiscoveryClient(discoveryAddress string, pollingDuration time.Duration, 
 		return nil, ErrInvalidPollingDuration
 	}
 
-	return newDiscoveryClient(discoveryAddress, new(ServerList), pollingDuration)
+	return newDiscoveryClient(discoveryAddress, new(ServerList), pollingDuration, opts...)
 }
 
 func NewDynamicRendezvousClient(discoveryAddress string, pollingDuration time.Duration, opts ...ClientOption) (*Client, error) {
@@ -145,7 +144,7 @@ func NewDynamicRendezvousClient(discoveryAddress string, pollingDuration time.Du
 		return nil, ErrInvalidPollingDuration
 	}
 
-	return newDiscoveryClient(discoveryAddress, NewRendezvousSelector(), pollingDuration)
+	return newDiscoveryClient(discoveryAddress, NewRendezvousSelector(), pollingDuration, opts...)
 }
 
 // for the unit test
@@ -164,22 +163,13 @@ func newDiscoveryClient(discoveryAddress string, selector ServerSelector, pollin
 
 type ClientOption func(*Client)
 
-// WithTLS sets the dial context function for the client.
-func WithTLS() ClientOption {
-	return func(c *Client) {
-		c.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
-			return tls.Dial(network, address, &tls.Config{})
-		}
-	}
-}
-
 // New returns a memcache client using the provided server(s)
 // with equal weight. If a server is listed multiple times,
 // it gets a proportional amount of weight.
 func New(server []string, opts ...ClientOption) *Client {
 	ss := new(ServerList)
 	ss.SetServers(server...)
-	return NewFromSelector(ss)
+	return NewFromSelector(ss, opts...)
 }
 
 // NewFromSelector returns a new Client using the provided ServerSelector.

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -49,7 +49,7 @@ func TestLocalhost(t *testing.T) {
 	io.WriteString(c, "flush_all\r\n")
 	c.Close()
 
-	testWithClient(t, New(localhostTCPAddr))
+	testWithClient(t, New([]string{localhostTCPAddr}))
 }
 
 // Run the memcached binary as a child process and connect to its unix socket.
@@ -72,7 +72,7 @@ func TestUnixSocket(t *testing.T) {
 		time.Sleep(time.Duration(25*i) * time.Millisecond)
 	}
 
-	testWithClient(t, New(sock))
+	testWithClient(t, New([]string{sock}))
 }
 
 func TestFakeServer(t *testing.T) {
@@ -86,7 +86,7 @@ func TestFakeServer(t *testing.T) {
 	srv := &testServer{}
 	go srv.Serve(ln)
 
-	testWithClient(t, New(ln.Addr().String()))
+	testWithClient(t, New([]string{ln.Addr().String()}))
 }
 
 func TestTLS(t *testing.T) {
@@ -148,7 +148,7 @@ func TestTLS(t *testing.T) {
 		time.Sleep(time.Duration(25*i) * time.Millisecond)
 	}
 
-	c := New(net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	c := New([]string{net.JoinHostPort("127.0.0.1", strconv.Itoa(port))})
 	c.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		var td tls.Dialer
 		td.Config = &tls.Config{
@@ -412,7 +412,7 @@ func BenchmarkOnItem(b *testing.B) {
 	}()
 
 	addr := fakeServer.Addr()
-	c := New(addr.String())
+	c := New([]string{addr.String()})
 	if _, err := c.getConn(addr); err != nil {
 		b.Fatal("failed to initialize connection to fake server")
 	}


### PR DESCRIPTION
Allow setting a TLS opt for the client. Both the discovery client, and the rendezvous client. 

